### PR TITLE
Fix objectKeyFormat configuration naming

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -21,7 +21,7 @@ function formatKey(input) {
   log.debug(`save-to-s3: parsing format string: ${input.objectKeyFormat}`);
   let result =
     // eslint-disable-next-line no-template-curly-in-string
-    input.keyFormat || '${resource.id}_${resource.startedAt}.${format}';
+    input.objectKeyFormat || '${resource.id}_${resource.startedAt}.${format}';
   const replaceMatches = result.match(/\$\{[^$]*\}/g);
   if (replaceMatches) {
     log.debug(`save-to-s3: found ${replaceMatches.length} replacement tags`);

--- a/src/actor.js
+++ b/src/actor.js
@@ -18,7 +18,7 @@ function getProperty(propertyName, object) {
 }
 
 function formatKey(input) {
-  log.debug(`save-to-s3: parsing format string: ${input.keyFormat}`);
+  log.debug(`save-to-s3: parsing format string: ${input.objectKeyFormat}`);
   let result =
     // eslint-disable-next-line no-template-curly-in-string
     input.keyFormat || '${resource.id}_${resource.startedAt}.${format}';


### PR DESCRIPTION
Hey @rixw this actor was super helpful!

I think this change should allow using custom `objectKeyFormat`s. Let me know if looks OK to you.